### PR TITLE
Add user manual link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ We are using mkdocs to manage our documentation.
 
 # Contributing
 
-We're really happy if you want to contribut to make the documention better!
+We're really happy if you want to contribute to make the documentation better!
 This is done by creating a pull request.
 
 1. Install dependencies

--- a/docs/explorer-kit/introduction.md
+++ b/docs/explorer-kit/introduction.md
@@ -25,6 +25,10 @@ Once the position is known relative to the Receivers, the global position can be
 
 [Getting started with Waterlinked Underwater GPS](https://waterlinked.github.io/docs/explorer-kit/quickstart/)
 
+## User Manual
+
+[Waterlinked Underwater GPS User Manual](https://waterlinked.com/wp-content/uploads/2017/08/W-DN-17002-2_Underwater_GPS_User_Manual.pdf)
+
 ## Collaboration
 
 This document is created using markdown and is hosted on GitHub. If you find something that is not documented well enough, typos or any other mistakes. Please open an issue or create a pull request to fix the problem. </br>Or just simply hit the edit button on the top of the page.

--- a/docs/explorer-kit/introduction.md
+++ b/docs/explorer-kit/introduction.md
@@ -27,7 +27,7 @@ Once the position is known relative to the Receivers, the global position can be
 
 ## Collaboration
 
-This document is created using markdown and is hosted on GitHub. If you find somthing that is not docomented well enough, typos or any other mistakes. Please open an issue or create a pull request to fix the problem. </br>Or just simply hit the edit button on the top of the page.
+This document is created using markdown and is hosted on GitHub. If you find something that is not documented well enough, typos or any other mistakes. Please open an issue or create a pull request to fix the problem. </br>Or just simply hit the edit button on the top of the page.
 
 ## Discussion
 

--- a/docs/explorer-kit/introduction.md
+++ b/docs/explorer-kit/introduction.md
@@ -31,5 +31,4 @@ This document is created using markdown and is hosted on GitHub. If you find som
 
 ## Discussion
 
-If you have more questions which is not answered on this page please go to our [forum](https://waterlinked.com/forums/forum/underwater-gps/) where we will be happy to answer you. 
-
+If you have more questions which is not answered on this page please go to our [forum](https://waterlinked.com/forums/forum/underwater-gps/) where we will be happy to answer you.


### PR DESCRIPTION
I could not find this doc anywhere on your site (store or docs). I found this only via google.
PS The [user manual link](https://waterlinked.com/usermanual/) in your store product page redirects to the docs site.