### PR TITLE
Refactor DVL documentation: add latency information and mark obsolete…

### DIFF
--- a/docs/dvl/faq.md
+++ b/docs/dvl/faq.md
@@ -50,3 +50,7 @@ It can also be a sign of a bad connection. If the DVL has been working properly 
 **Q9: Can the DVL overheat?**
 
 **A9:** The DVL has a thermal shutdown to prevent temperatures that can damage the DVL. The DVL will give a warning that it will soon do a thermal shutdown. Please see [Protocol](dvl-protocol.md). It will shutdown at 55℃ and when it reaches below 50℃ it will automatically turn it self on an continue where it left off before the shutdown.  It will continue in a loop with shutdown and rebooting if the overheating issue is not addressed. 
+
+**Q10: What is the latency when using the API over Ethernet?**
+
+**A10:** When sending commands over TCP, the latency averages around 4 ms, with a standard deviation of 2 ms. The maximum observed latency is 13 ms.

--- a/docs/dvl/interfaces.md
+++ b/docs/dvl/interfaces.md
@@ -94,7 +94,7 @@ See [networking](../networking) and the DVL's [TCP protocol](../dvl-protocol#eth
 
 ##  I/O interface
 
-The I/O Interface provides a simple means of connection to the Water Linked DVLs. It provides magnetics for the ethernet connection and utilizes the Molex Micro-Fit 3.0 power connector which is standard for Water Linked products.
+The I/O Interface provides a simple means of connection to the Water Linked DVLs. It provides magnetics for the ethernet connection and utilizes the Molex Micro-Fit 3.0 power connector (Part number: 436500204) which is standard for Water Linked products. Female connectors is listed under [Mates with Part(s)](https://www.molex.com/en-us/products/part-detail/436500204#mates-with-use-with) 
 
 There currently exists three revisions of the I/O Interface. Revision 2 and 3 are electrically identical. Revision 4 has an integrated USB-to-UART interface and a micro USB port.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,7 +77,7 @@ nav:
           - Locators:
               - Locator-A1: explorer-kit/locators/locator-a1.md
               - Locator-D1: explorer-kit/locators/locator-d1.md
-              - Locator-S1: explorer-kit/locators/locator-s1.md
+              - Locator-S1 (obsolete): explorer-kit/locators/locator-s1.md
               - Locator-U1: explorer-kit/locators/locator-u1.md
           - GUI:
               - Position: explorer-kit/gui/position.md


### PR DESCRIPTION
Update:

1. DVL,TCP latency in FAQ
2. S1 locator marked with obsolete
3. Added information about female connector to Molex micro fit I/O board. 